### PR TITLE
修正了参数名不对应的问题

### DIFF
--- a/tensorflowTUT/tf20_RNN2.2/full_code.py
+++ b/tensorflowTUT/tf20_RNN2.2/full_code.py
@@ -100,8 +100,8 @@ class LSTMRNN(object):
                 name='average_cost')
             tf.summary.scalar('cost', self.cost)
 
-    def ms_error(self, y_target, y_pre):
-        return tf.square(tf.subtract(y_target, y_pre))
+    def ms_error(self, labels, logits):
+        return tf.square(tf.subtract(labels, logits))
 
     def _weight_variable(self, shape, name='weights'):
         initializer = tf.random_normal_initializer(mean=0., stddev=1.,)


### PR DESCRIPTION
将原来的ms_error函数的参数名修正为softmax_loss_function源码中使用的labels和logits