### PR TITLE
解决报错ValueError

### DIFF
--- a/kerasTUT/6-CNN_example.py
+++ b/kerasTUT/6-CNN_example.py
@@ -37,7 +37,7 @@ model = Sequential()
 
 # Conv layer 1 output shape (32, 28, 28)
 model.add(Convolution2D(
-    batch_input_shape=(64, 1, 28, 28),
+    batch_input_shape=(None, 1, 28, 28),
     filters=32,
     kernel_size=5,
     strides=1,


### PR DESCRIPTION
运行时报错：
ValueError: Cannot feed value of shape (32, 1, 28, 28) for Tensor `conv2d_23_input:0`, which has shape `(64, 1, 28, 28)`

因为数据集的长度要是batch_size的整数倍，或者把这个改成batch_input_shape=(None,28, 28,1)就可以了