### PR TITLE
docs: fix simple typo, inital -> initial

### DIFF
--- a/theanoTUT/theano6_shared_variable.py
+++ b/theanoTUT/theano6_shared_variable.py
@@ -12,7 +12,7 @@ import numpy as np
 import theano
 import theano.tensor as T
 
-state = theano.shared(np.array(0,dtype=np.float64), 'state') # inital state = 0
+state = theano.shared(np.array(0,dtype=np.float64), 'state') # initial state = 0
 inc = T.scalar('inc', dtype=state.dtype)
 accumulator = theano.function([inc], state, updates=[(state, state+inc)])
 


### PR DESCRIPTION
There is a small typo in theanoTUT/theano6_shared_variable.py.

Should read `initial` rather than `inital`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md